### PR TITLE
Build d64 with containerized c1541

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
+# c1541 runs from a pinned image; set C1541 to use a host VICE install instead.
+# HOME must be writable by the calling uid or VICE logs errors creating its
+# config, cache and state directories.
+VICE_IMAGE ?= anarkiwi/asid-vice:3.10.0.0
+DOCKER_RUN := docker run --rm -u $(shell id -u):$(shell id -g) \
+    -v $(CURDIR):/work -w /work
+C1541 ?= $(DOCKER_RUN) -e HOME=/tmp --entrypoint c1541 $(VICE_IMAGE)
+
 all: vvf.d64 vvf.prg
 
 vvf.prg: vvf.c vessel.h
 	cl65 -Osir -Cl vvf.c -o vvf.prg
 
 vvf.d64: vvf.prg
-	c1541 -format diskname,id d64 vvf.d64 -attach vvf.d64 -write vvf.prg vvf
+	$(C1541) -format diskname,id d64 vvf.d64 -attach vvf.d64 -write vvf.prg vvf
 
 upload: all
 	ncftpput -p "" -Cv c64 vvf.prg /Temp/vvf.prg

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
+# c1541 runs from a container (see Makefile); cc65 is still built from source.
 export DEBIAN_FRONTEND=noninteractive && \
 echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
 sudo apt-get update && \
-sudo apt-get install -yq --no-install-recommends git vice && \
+sudo apt-get install -yq --no-install-recommends git && \
 git clone -b V2.19 https://github.com/cc65/cc65 && \
 cd cc65 && make && sudo PREFIX=/usr/local make install && cd .. && \
 make


### PR DESCRIPTION
Same pattern as anarkiwi/vap#48, limited to `c1541`: it now runs from `anarkiwi/asid-vice:3.10.0.0` instead of the apt `vice` package, which drops that install from `build.sh`.

`cl65` still comes from the cc65 source build — there is no cc65 image to point at, so this repo only gets the VICE half of the change.

Verified the `c1541` step directly (formats and writes the d64, correct ownership, no VICE config errors). I could not exercise `make` end to end here since cl65 is not installed in this environment; CI covers that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQJ4Gg9DFXQnkHfSobkAqR